### PR TITLE
Resource Imports

### DIFF
--- a/Volatility/CLI/Commands/AutotestCommand.cs
+++ b/Volatility/CLI/Commands/AutotestCommand.cs
@@ -48,7 +48,7 @@ internal class AutotestCommand : ICommand
         TexturePC textureHeaderPC = new TexturePC
         {
             AssetName = "autotest_header_PC",
-            ResourceID = GetResourceIDFromName("autotest_header_PC", Endian.LE),
+            ResourceID = GetResourceIDFromName("autotest_header_PC"),
             Format = D3DFORMAT.D3DFMT_DXT1,
             Width = 1024,
             Height = 512,
@@ -62,7 +62,7 @@ internal class AutotestCommand : ICommand
         TextureBPR textureHeaderBPR = new TextureBPR
         {
             AssetName = "autotest_header_BPR",
-            ResourceID = GetResourceIDFromName("autotest_header_BPR", Endian.LE),
+            ResourceID = GetResourceIDFromName("autotest_header_BPR"),
             Format = DXGI_FORMAT.DXGI_FORMAT_BC1_UNORM,
             Width = 1024,
             Height = 512,
@@ -77,7 +77,7 @@ internal class AutotestCommand : ICommand
 
         textureHeaderBPR.SetResourceArch(Arch.x64);
         textureHeaderBPR.AssetName = "autotest_header_BPRx64";
-        textureHeaderBPR.ResourceID = GetResourceIDFromName(textureHeaderBPR.AssetName, Endian.LE);
+        textureHeaderBPR.ResourceID = GetResourceIDFromName(textureHeaderBPR.AssetName);
 
         // Write 64 bit test BPR header
         TestHeaderRW("autotest_header_BPRx64.dat", textureHeaderBPR);
@@ -86,7 +86,7 @@ internal class AutotestCommand : ICommand
         TexturePS3 textureHeaderPS3 = new TexturePS3
         {
             AssetName = "autotest_header_PS3",
-            ResourceID = GetResourceIDFromName("autotest_header_PS3", Endian.BE),
+            ResourceID = GetResourceIDFromName("autotest_header_PS3"),
             Format = CELL_GCM_COLOR_FORMAT.CELL_GCM_TEXTURE_COMPRESSED_DXT45,
             Width = 1024,
             Height = 512,
@@ -100,7 +100,7 @@ internal class AutotestCommand : ICommand
         TextureX360 textureHeaderX360 = new TextureX360
         {
             AssetName = "autotest_header_X360",
-            ResourceID = GetResourceIDFromName("autotest_header_X360", Endian.BE),
+            ResourceID = GetResourceIDFromName("autotest_header_X360"),
             Format = new GPUTEXTURE_FETCH_CONSTANT
             {
                 Tiled = true,

--- a/Volatility/CLI/Commands/ImportResourceCommand.cs
+++ b/Volatility/CLI/Commands/ImportResourceCommand.cs
@@ -72,8 +72,9 @@ internal partial class ImportResourceCommand : ICommand
 				var serializer = new SerializerBuilder()
     				.DisableAliases()
     				.WithTypeInspector(inner => new IncludeFieldsTypeInspector(inner))
-    				.WithTypeConverter(new ResourceYamlTypeConverter())
-    				.WithTypeConverter(new StringEnumYamlTypeConverter())
+                    .WithTypeConverter(new ResourceYamlTypeConverter())
+                    .WithTypeConverter(new ResourceIDYamlTypeConverter())
+                    .WithTypeConverter(new StringEnumYamlTypeConverter())
     				.Build();
 				
 				var serializedString = new string("");

--- a/Volatility/Resources/EnvironmentKeyframe/EnvironmentKeyframe.cs
+++ b/Volatility/Resources/EnvironmentKeyframe/EnvironmentKeyframe.cs
@@ -156,10 +156,13 @@ public struct VignetteData
 
 public struct TintData 
 {
-    public ulong ColorCubePtr; // TODO: Update with new ResourceID system
+    public ResourceImport ColorCubeReference;
     public TintData(ResourceBinaryReader reader, Arch arch) 
     {
-        ColorCubePtr = (arch == Arch.x64 ? reader.ReadUInt64() : reader.ReadUInt32());
+        ColorCubeReference.ReferenceID = (arch == Arch.x64 ? reader.ReadUInt64() : reader.ReadUInt32());
+        
+        if (ResourceImport.ReadExternalImport(0, reader, 0x240, out ResourceImport ExternalReference))
+            ColorCubeReference = ExternalReference;
     }
 }
 

--- a/Volatility/Resources/InstanceList/InstanceList.cs
+++ b/Volatility/Resources/InstanceList/InstanceList.cs
@@ -67,10 +67,10 @@ public class InstanceList : Resource
                 // Padding1 = _padding1, Padding2 = _padding2,
                 MaxVisibleDistanceSquared = _maxVisibleDistanceSquared,
                 Transform = _transform,
-                ResourceId = new ResourceID
+                ResourceId = new ResourceImport
                 {
-                    ID = reader.ReadBytes(4),
-                    Endian = reader.GetEndianness()
+                    ReferenceID = reader.ReadUInt32(),
+                    ExternalImport = false
                 },
             });
         }
@@ -80,7 +80,7 @@ public class InstanceList : Resource
 public struct Instance
 {
     [EditorLabel("Resource ID"), EditorCategory("InstanceList/Instances"), EditorTooltip("The reference to the resource placed by this instance.")]
-    public ResourceID ResourceId;
+    public ResourceImport ResourceId;
 
     [EditorLabel("Transform"), EditorCategory("InstanceList/Instances"), EditorTooltip("The location, rotation, and scale of this instance.")]
     public Transform Transform;

--- a/Volatility/Resources/Model/Model.cs
+++ b/Volatility/Resources/Model/Model.cs
@@ -96,9 +96,16 @@ public class Model : Resource
 
         Flags = reader.ReadByte();
 
+        var maxLength = new[]
+        {
+            lodDistancesPtr + numRenderables * sizeof(uint),
+            renderablesPtr + numRenderables * sizeof(uint),
+            renderableStatesPtr + numRenderables
+        }.Max();
+
         // This currently does a lot of seeking.
         // It may improve performance if we separate this.
-        for (uint i = 0; i < numRenderables; i++)
+        for (int i = 0; i < numRenderables; i++)
         {
             ModelData modelData = new ModelData();
             
@@ -119,7 +126,8 @@ public class Model : Resource
                 (reader.GetEndianness() == Endian.BE ? 0x4 : 0x0), SeekOrigin.Begin
             );
 
-            modelData.ResourceReference.ReferenceID = reader.ReadUInt32();
+            ResourceImport.ReadExternalImport(i, reader, maxLength, out modelData.ResourceReference);
+
             ModelDatas.Add(modelData);
         }
     }

--- a/Volatility/Resources/Model/Model.cs
+++ b/Volatility/Resources/Model/Model.cs
@@ -60,8 +60,7 @@ public class Model : Resource
         // Resource ID References
         for (int i = 0; i < models; i++)
         {
-            writer.Write(ModelDatas[i].ResourceReference.Endian == Endian.BE ? new byte[4] : ModelDatas[i].ResourceReference.ID);
-            writer.Write(ModelDatas[i].ResourceReference.Endian == Endian.LE ? new byte[4] : ModelDatas[i].ResourceReference.ID);
+            writer.Write(ModelDatas[i].ResourceReference.ReferenceID);
             writer.Write(renderablesPtr + (i * 0x4));
             writer.Write((uint)0x0); // Unknown. Always 0 in BPR, not always 0 on X360
         }
@@ -120,9 +119,7 @@ public class Model : Resource
                 (reader.GetEndianness() == Endian.BE ? 0x4 : 0x0), SeekOrigin.Begin
             );
 
-            modelData.ResourceReference.ID = reader.ReadBytes(4);
-            modelData.ResourceReference.Endian = reader.GetEndianness();
-
+            modelData.ResourceReference.ReferenceID = reader.ReadUInt32();
             ModelDatas.Add(modelData);
         }
     }
@@ -134,7 +131,7 @@ public class Model : Resource
     public struct ModelData
     {
         [EditorCategory("Model Data"), EditorLabel("Resource Reference")]
-        public ResourceID ResourceReference;
+        public ResourceImport ResourceReference;
 
         [EditorCategory("Model Data"), EditorLabel("Model State")]
         public State State;

--- a/Volatility/Resources/Resource.cs
+++ b/Volatility/Resources/Resource.cs
@@ -86,7 +86,7 @@ public abstract class Resource
                     : name
                     , 16);
 
-                string newName = GetNameByResourceID(ResourceID, GetResourceType().ToString());
+                string newName = GetNameByResourceID(ResourceID);
                 AssetName = !string.IsNullOrEmpty(newName)
                     ? newName
                     : ResourceID.ToString();

--- a/Volatility/Resources/Resource.cs
+++ b/Volatility/Resources/Resource.cs
@@ -89,7 +89,7 @@ public abstract class Resource
                 string newName = GetNameByResourceID(ResourceID, GetResourceType().ToString());
                 AssetName = !string.IsNullOrEmpty(newName)
                     ? newName
-                    : ResourceID.ToString("X8");
+                    : ResourceID.ToString();
             }
             else
             {

--- a/Volatility/Resources/ResourceImport.cs
+++ b/Volatility/Resources/ResourceImport.cs
@@ -1,5 +1,7 @@
 ﻿using YamlDotNet.Serialization;
 
+using static Volatility.Utilities.ResourceIDUtilities;
+
 namespace Volatility.Resources;
 
 public struct ResourceImport
@@ -13,15 +15,21 @@ public struct ResourceImport
     public ResourceID ReferenceID;
     public bool ExternalImport;
 
-    public ResourceImport() { }
+    public ResourceImport() 
+    {
+        Name = string.Empty;
+    }
 
     public ResourceImport(ResourceID id, bool externalImport = false, bool useCalculatedName = false)
     {
         ReferenceID = id;
         ExternalImport = externalImport;
-        // TODO: find name in ResourceDB, pending ResourceDB v3
-        // if (useCalculatedName || resource was found in db)
-        //     ReferenceID = 0x0;
+        Name = GetNameByResourceID(id);
+
+        if (Name.Length > 0 && useCalculatedName)
+        {
+            ReferenceID = 0x0;
+        }
     }
 
     public ResourceImport(string name, bool externalImport = false)

--- a/Volatility/Resources/ResourceImport.cs
+++ b/Volatility/Resources/ResourceImport.cs
@@ -1,7 +1,61 @@
-﻿namespace Volatility.Resources;
+﻿using YamlDotNet.Serialization;
+
+namespace Volatility.Resources;
 
 public struct ResourceImport
 {
     public ResourceID ReferenceID;
     public bool ExternalImport;
-}
+
+    public static bool ReadExternalImport(byte index, EndianAwareBinaryReader reader, long importBlockOffset, out ResourceImport resourceImport)
+    {
+        resourceImport.ExternalImport = true;
+
+        // In-resource imports block
+        if (reader.BaseStream.Length >= importBlockOffset + (0x10 * index) + 0x10)
+        {
+            long originalPosition = reader.BaseStream.Position;
+            
+            reader.BaseStream.Seek(importBlockOffset + (0x10 * index), SeekOrigin.Begin);
+            
+            resourceImport.ReferenceID = reader.ReadUInt64();
+            
+            reader.BaseStream.Seek(originalPosition, SeekOrigin.Begin);
+            
+            return true;
+        }
+        // YAP imports yaml
+        else if (reader.BaseStream is FileStream fs)
+        {
+            string baseName = Path.GetFileNameWithoutExtension(fs.Name);
+
+            string directory = Path.GetDirectoryName(fs.Name);
+
+            resourceImport.ReferenceID = GetYAMLImportValueAt(Path.Combine(directory, baseName + "_imports.yaml"), index);
+
+            return true;
+        }
+
+        resourceImport = default;
+        return false;
+    }
+
+
+    public static ResourceID GetYAMLImportValueAt(string yamlPath, byte index)
+    {
+        var yaml = File.ReadAllText(yamlPath);
+        var deser = new DeserializerBuilder().Build();
+
+        var list = deser
+            .Deserialize<List<Dictionary<string, string>>>(yaml)
+            ?? throw new InvalidDataException("Expected a YAML sequence of mappings.");
+
+        if (index < 0 || index >= list.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"Valid range 0–{list.Count - 1}");
+
+        var kv = list[index].Values.GetEnumerator();
+        kv.MoveNext();
+        return Convert.ToUInt32(kv.Current, 16);
+    }
+};
+

--- a/Volatility/Resources/ResourceImport.cs
+++ b/Volatility/Resources/ResourceImport.cs
@@ -30,7 +30,7 @@ public struct ResourceImport
         ExternalImport = externalImport;
     }
 
-    public static bool ReadExternalImport(byte index, EndianAwareBinaryReader reader, long importBlockOffset, out ResourceImport resourceImport)
+    public static bool ReadExternalImport(int index, EndianAwareBinaryReader reader, long importBlockOffset, out ResourceImport resourceImport)
     {
         // In-resource imports block
         if (reader.BaseStream.Length >= importBlockOffset + (0x10 * index) + 0x10)
@@ -62,7 +62,7 @@ public struct ResourceImport
     }
 
 
-    public static ResourceID GetYAMLImportValueAt(string yamlPath, byte index)
+    public static ResourceID GetYAMLImportValueAt(string yamlPath, int index)
     {
         var yaml = File.ReadAllText(yamlPath);
         var deser = new DeserializerBuilder().Build();

--- a/Volatility/Resources/ResourceImport.cs
+++ b/Volatility/Resources/ResourceImport.cs
@@ -1,0 +1,7 @@
+﻿namespace Volatility.Resources;
+
+public struct ResourceImport
+{
+    public ResourceID ReferenceID;
+    public bool ExternalImport;
+}

--- a/Volatility/Types.cs
+++ b/Volatility/Types.cs
@@ -8,6 +8,7 @@ global using Vector3Plus = System.Numerics.Vector4;     // VectorIntrinsic
 global using Vector4 = System.Numerics.Vector4;
 global using Quaternion = System.Numerics.Quaternion;
 global using Matrix44Affine = System.Numerics.Matrix4x4;
+global using ResourceID = System.UInt64;
 
 // Volatilty Types
 global using ColorRGB = System.Numerics.Vector3;
@@ -19,27 +20,4 @@ public struct Transform
     public Vector3 Location;
     public Quaternion Rotation;
     public Vector3 Scale;    
-}
-
-// Experimenting with a new way to store ResourceIDs.
-public struct ResourceID
-{
-    [Newtonsoft.Json.JsonIgnore]
-    public byte[] ID;
-
-    public string HexID
-    {
-        get => BitConverter.ToString(ID).Replace("-", "").ToLower();
-        set => ID = Enumerable.Range(0, value.Length / 2)
-                              .Select(x => Convert.ToByte(value.Substring(x * 2, 2), 16))
-                              .ToArray();
-    }
-
-    public Endian Endian;
-
-    public ResourceID()
-    {
-        ID = new byte[4];
-        Endian = default;
-    }
 }

--- a/Volatility/Types.cs
+++ b/Volatility/Types.cs
@@ -8,7 +8,6 @@ global using Vector3Plus = System.Numerics.Vector4;     // VectorIntrinsic
 global using Vector4 = System.Numerics.Vector4;
 global using Quaternion = System.Numerics.Quaternion;
 global using Matrix44Affine = System.Numerics.Matrix4x4;
-global using ResourceID = System.UInt64;
 
 // Volatilty Types
 global using ColorRGB = System.Numerics.Vector3;
@@ -20,4 +19,13 @@ public struct Transform
     public Vector3 Location;
     public Quaternion Rotation;
     public Vector3 Scale;    
+}
+
+public readonly struct ResourceID
+{
+    public readonly ulong Value;
+    public ResourceID(ulong v) => Value = v;
+    public static implicit operator ulong(ResourceID r) => r.Value;
+    public static implicit operator ResourceID(ulong v) => new ResourceID(v);
+    public override string ToString() => $"{Value:X8}";
 }

--- a/Volatility/Utilities/ResourceIDUtilities.cs
+++ b/Volatility/Utilities/ResourceIDUtilities.cs
@@ -89,14 +89,14 @@ public static class ResourceIDUtilities
         return string.Concat(FlipResourceIDEndian(ResourceNameToResourceID(ResourceID)));
     }
 
-    public static string GetNameByResourceID(string id, string type)
+    public static string GetNameByResourceID(string id)
     {
         string path = Path.Combine
         (
-            Directory.GetCurrentDirectory(), 
-            "data", 
-            "ResourceDB", 
-            $"{type}.json"
+            Directory.GetCurrentDirectory(),
+            "data",
+            "ResourceDB",
+            "ResourceDB.json"
         );
 
         if (File.Exists(path))
@@ -108,21 +108,27 @@ public static class ResourceIDUtilities
 
         return "";
     }
-    public static string GetNameByResourceID(ResourceID id, string type)
+
+    public static string GetNameByResourceID(ResourceID id)
     {
         string path = Path.Combine
         (
             Directory.GetCurrentDirectory(),
             "data",
             "ResourceDB",
-            $"{type}.json"
+            "ResourceDB.json"
         );
 
         if (File.Exists(path))
         {
-            Dictionary<string, string>? data = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(path));
+            Dictionary<string, string>? data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            return data.TryGetValue($"{id.ToString():X8}", out string? value) ? value : "";
+            using var reader = File.OpenText(path);
+            using var json = new JsonTextReader(reader);
+            new JsonSerializer()
+                .Populate(json, data);
+
+            return data.TryGetValue(id.ToString(), out string? value) ? value : "";
         }
 
         return "";

--- a/Volatility/Utilities/ResourceIDUtilities.cs
+++ b/Volatility/Utilities/ResourceIDUtilities.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Hashing;
+﻿using System.Buffers.Binary;
+using System.IO.Hashing;
 using System.Text;
 
 using Newtonsoft.Json;
@@ -107,6 +108,25 @@ public static class ResourceIDUtilities
 
         return "";
     }
+    public static string GetNameByResourceID(ResourceID id, string type)
+    {
+        string path = Path.Combine
+        (
+            Directory.GetCurrentDirectory(),
+            "data",
+            "ResourceDB",
+            $"{type}.json"
+        );
+
+        if (File.Exists(path))
+        {
+            Dictionary<string, string>? data = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(path));
+
+            return data.TryGetValue($"{id.ToString():X8}", out string? value) ? value : "";
+        }
+
+        return "";
+    }
 
     public static string GetResourceIDFromName(string name, Endian endian = Endian.LE)
     {
@@ -118,5 +138,10 @@ public static class ResourceIDUtilities
         }
 
         return BitConverter.ToString(hash).Replace("-", "_").ToUpper();
+    }
+
+    public static ResourceID GetResourceIDFromName(string name)
+    {
+        return BinaryPrimitives.ReadUInt32BigEndian(Crc32.Hash(Encoding.UTF8.GetBytes(name.ToLower())));
     }
 }

--- a/Volatility/Utilities/YAML/ResourceIDYamlTypeConverter.cs
+++ b/Volatility/Utilities/YAML/ResourceIDYamlTypeConverter.cs
@@ -1,0 +1,33 @@
+﻿using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Volatility.Utilities;
+
+public class ResourceIDYamlTypeConverter : IYamlTypeConverter
+{
+    public bool Accepts(Type type) => type == typeof(ResourceID);
+
+    public object ReadYaml(IParser parser, Type type, ObjectDeserializer nestedObjectDeserializer)
+    {
+        var scalar = parser.Consume<Scalar>().Value;
+        var hex = scalar.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                   ? scalar.Substring(2)
+                   : scalar;
+        var ul = Convert.ToUInt64(hex, 16);
+        return new ResourceID(ul);
+    }
+
+    public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer nestedObjectSerializer)
+    {
+        var text = value.ToString();
+        emitter.Emit(new Scalar(
+            anchor: null,
+            tag: null,
+            value: text,
+            style: ScalarStyle.Plain,
+            isPlainImplicit: true,
+            isQuotedImplicit: false
+        ));
+    }
+}

--- a/Volatility/Utilities/YAML/ResourceYamlDeserializer.cs
+++ b/Volatility/Utilities/YAML/ResourceYamlDeserializer.cs
@@ -43,6 +43,7 @@ public static class ResourceYamlDeserializer
 
         var finalDeserializer = new DeserializerBuilder()
             .IgnoreUnmatchedProperties()
+            .WithTypeConverter(new ResourceIDYamlTypeConverter())
             .Build();
         using (var reader = new StringReader(mergedYaml))
         {


### PR DESCRIPTION
Adds the underlying system for specifying resource imports/dependencies, this will be particularly useful for building bundles. Writing the dependency block is currently unimplemented, mainly because different bundle unpacker tools handle imports differently. This will hopefully be fixed with the integration of a bundle library, as we can simply pass the list of external imports to it, but for now we can at least store them in imported resources.